### PR TITLE
YOUR-RUNTIME-DOMAIN already has twil.io in copied link.

### DIFF
--- a/runtime/portable-fax-received.twiml
+++ b/runtime/portable-fax-received.twiml
@@ -3,5 +3,5 @@
   	<Receive 
       mediaType="image/tiff" 
       storeMedia="true" 
-      action="https://{{YOUR-RUNTIME-DOMAIN-HERE}}twil.io/portable-fax-received" />
+      action="https://{{YOUR-RUNTIME-DOMAIN-HERE}}/portable-fax-received" />
 </Response>


### PR DESCRIPTION
When you click Copy Button the link has the format: your-runtime-domain.twilio.io

I have removed twilio.io in the action value to avoid duplicate.